### PR TITLE
Fix Tailwind config import

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 
 // Import the defaultTheme to access Tailwind's default font stack
-const defaultTheme = require("tailwindcss/defaultTheme");
+import defaultTheme from "tailwindcss/defaultTheme.js";
 
 export default {
   // Add darkMode strategy: 'class'


### PR DESCRIPTION
## Summary
- update `tailwind.config.js` to use ESM `import` syntax instead of `require`

## Testing
- `npm run build`
- `npm run lint` *(fails: 52 problems)*

------
https://chatgpt.com/codex/tasks/task_e_683f88f7597483228f171cbac0f4d298