### PR TITLE
Fix comment typo in Vite config

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -4,5 +4,5 @@ import react from "@vitejs/plugin-react";
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-  base: "/", // Crutial for GitHub Pages deployment
+  base: "/", // Crucial for GitHub Pages deployment
 });


### PR DESCRIPTION
## Summary
- fix a typo in `vite.config.js`'s GitHub Pages comment

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f8bb8ae70832285da60b154d685bf